### PR TITLE
Add support for path parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  xcode_15_3:
+  xcode_15_4:
     runs-on: macos-14
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/FlyingFox.podspec.json
+++ b/FlyingFox.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "FlyingFox",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "summary": "Lightweight, HTTP server written in Swift using async/await",
   "homepage": "https://github.com/swhitty/FlyingFox",
   "authors": "Simon Whitty",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/swhitty/FlyingFox.git",
-    "tag": "0.14.0"
+    "tag": "0.15.0"
   },
   "platforms": {
     "ios": "13.0",
@@ -19,7 +19,7 @@
   },
   "source_files": "FlyingFox/Sources/**/*.swift",
   "dependencies": {
-    "FlyingSocks": "~> 0.14.0"
+    "FlyingSocks": "~> 0.15.0"
   },
   "swift_version": "5.8"
 }

--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -46,7 +46,7 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         self.storage = .complete(data)
     }
 
-    public init(from bytes: some AsyncChunkedSequence<UInt8>, count: Int) {
+    public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int) {
         self.storage = .dataSequence(
             AsyncDataSequence(from: bytes, count: count, chunkSize: 4096)
         )
@@ -56,7 +56,7 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         try self.init(file: url, chunkSize: 4096)
     }
 
-    init(from bytes: some AsyncChunkedSequence<UInt8>, count: Int, chunkSize: Int) {
+    init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int, chunkSize: Int) {
         self.storage = .dataSequence(
             AsyncDataSequence(from: bytes, count: count, chunkSize: chunkSize)
         )

--- a/FlyingFox/Sources/HTTPBodySequence.swift
+++ b/FlyingFox/Sources/HTTPBodySequence.swift
@@ -32,6 +32,7 @@
 import Foundation
 import FlyingSocks
 @_spi(Private) import struct FlyingSocks.AsyncDataSequence
+@_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
 
 public struct HTTPBodySequence: Sendable, AsyncSequence {
     public typealias Element = Data
@@ -43,7 +44,7 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
     }
 
     public init(data: Data) {
-        self.storage = .complete(data)
+        self.init(data: data, bufferSize: 4096)
     }
 
     public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int) {
@@ -60,6 +61,14 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
         self.storage = .dataSequence(
             AsyncDataSequence(from: bytes, count: count, chunkSize: chunkSize)
         )
+    }
+
+    init(data: Data, bufferSize: Int) {
+#if compiler(>=5.9)
+        self.storage = .sequence(.init(data: data, bufferSize: bufferSize))
+#else
+        self.storage = .complete(data)
+#endif
     }
 
     init(file url: URL, maxSizeForComplete: Int = 10_485_760, chunkSize: Int) throws {
@@ -82,6 +91,24 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
     enum Storage: @unchecked Sendable {
         case complete(Data)
         case dataSequence(AsyncDataSequence)
+
+#if compiler(>=5.9)
+        case sequence(Sequence)
+
+        struct Sequence {
+            var sequence: any AsyncBufferedSequence<UInt8>
+            var count: Int
+            var bufferSize: Int
+            var canReplay: Bool
+
+            init(data: Data, bufferSize: Int) {
+                self.sequence = AsyncBufferedCollection(data)
+                self.count = data.count
+                self.bufferSize = bufferSize
+                self.canReplay = true
+            }
+        }
+#endif
     }
 
     public var count: Int {
@@ -90,6 +117,10 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
             return data.count
         case .dataSequence(let sequence):
             return sequence.count
+#if compiler(>=5.9)
+        case .sequence(let sequence):
+            return sequence.count
+#endif
         }
     }
 
@@ -101,12 +132,29 @@ public struct HTTPBodySequence: Sendable, AsyncSequence {
             return try await sequence.reduce(into: Data()) {
                 $0.append($1)
             }
+#if compiler(>=5.9)
+        case .sequence(let sequence):
+            return try await sequence.sequence.reduce(into: Data()) {
+                $0.append($1)
+            }
+#endif
         }
     }
 
     func flushIfNeeded() async throws {
         guard case .dataSequence(let sequence) = storage else { return }
         try await sequence.flushIfNeeded()
+    }
+
+    var canReplay: Bool {
+        switch storage {
+        case .complete: return true
+        case .dataSequence: return false
+#if compiler(>=5.9)
+        case .sequence(let sequence):
+            return sequence.canReplay
+#endif
+        }
     }
 }
 
@@ -117,13 +165,21 @@ public extension HTTPBodySequence {
 
         private var storage: Internal
         private var isComplete: Bool = false
+        private var bufferSize: Int = 0
 
         fileprivate init(storage: Storage) {
             switch storage {
             case .complete(let data):
                 self.storage = .complete(data)
+                self.bufferSize = 0
             case .dataSequence(let sequence):
                 self.storage = .dataIterator(sequence.makeAsyncIterator())
+                self.bufferSize = 0
+#if compiler(>=5.9)
+            case .sequence(let sequence):
+                self.storage = .iterator(sequence.sequence.makeAsyncIterator())
+                self.bufferSize = sequence.bufferSize
+#endif
             }
         }
 
@@ -140,12 +196,31 @@ public extension HTTPBodySequence {
                 }
                 storage = .dataIterator(iterator)
                 return result
+#if compiler(>=5.9)
+            case var .iterator(iterator):
+                guard let result = try await getNextBuffer(&iterator) else {
+                    isComplete = true
+                    return nil
+                }
+                storage = .iterator(iterator)
+                return result
+#endif
             }
+        }
+
+        private func getNextBuffer(_ iterator: inout some AsyncBufferedIteratorProtocol<UInt8>) async throws -> Data? {
+            guard let buffer = try await iterator.nextBuffer(atMost: bufferSize) else {
+                return nil
+            }
+            return Data(buffer)
         }
 
         enum Internal: @unchecked Sendable {
             case complete(Data)
             case dataIterator(AsyncDataSequence.AsyncIterator)
+#if compiler(>=5.9)
+            case iterator(any AsyncBufferedIteratorProtocol<UInt8>)
+#endif
         }
     }
 }

--- a/FlyingFox/Sources/HTTPChunkedEncodedSequence.swift
+++ b/FlyingFox/Sources/HTTPChunkedEncodedSequence.swift
@@ -1,0 +1,82 @@
+//
+//  HTTPChunkedTransferEncoder.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 09/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+import FlyingSocks
+
+struct HTTPChunkedTransferEncoder<Base>: AsyncBufferedSequence, Sendable
+    where Base: AsyncBufferedSequence,
+          Base.Element == UInt8,
+          Base: Sendable {
+    typealias Element = UInt8
+
+    private let bytes: Base
+
+    init(bytes: Base) {
+        self.bytes = bytes
+    }
+
+    func makeAsyncIterator() -> Iterator {
+        Iterator(bytes: bytes.makeAsyncIterator())
+    }
+}
+
+extension HTTPChunkedTransferEncoder {
+
+    struct Iterator: AsyncBufferedIteratorProtocol {
+
+        private var bytes: Base.AsyncIterator
+        private var isComplete: Bool = false
+
+        init(bytes: Base.AsyncIterator) {
+            self.bytes = bytes
+        }
+
+        mutating func next() async throws -> UInt8? {
+            fatalError("call nextBuffer(atMost:)")
+        }
+
+        mutating func nextBuffer(atMost count: Int) async throws -> [UInt8]? {
+            guard !isComplete else { return nil }
+
+            if let buffer = try await bytes.nextBuffer(atMost: count) {
+                var response = Array<UInt8>(String(format:"%02X", buffer.count).utf8)
+                response.append(contentsOf: Array("\r\n".utf8))
+                response.append(contentsOf: buffer)
+                response.append(contentsOf: Array("\r\n".utf8))
+                return response
+            } else {
+                isComplete = true
+                return Array("0\r\n\r\n".utf8)
+            }
+        }
+    }
+}

--- a/FlyingFox/Sources/HTTPClient.swift
+++ b/FlyingFox/Sources/HTTPClient.swift
@@ -1,0 +1,63 @@
+//
+//  HTTPClient.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 8/06/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import FlyingSocks
+
+@_spi(Private)
+public struct _HTTPClient {
+
+    public func sendHTTPRequest(_ request: HTTPRequest, to address: some SocketAddress) async throws -> HTTPResponse {
+        let socket = try await AsyncSocket.connected(to: address)
+        try await socket.writeRequest(request)
+        let response = try await socket.readResponse()
+        try? socket.close()
+        return response
+    }
+}
+
+@_spi(Private)
+public extension AsyncSocket {
+    func writeRequest(_ request: HTTPRequest) async throws {
+        try await write(HTTPEncoder.encodeRequest(request))
+    }
+
+    func readResponse() async throws -> HTTPResponse {
+        try await HTTPDecoder.decodeResponse(from: bytes)
+    }
+
+    func writeFrame(_ frame: WSFrame) async throws {
+        try await write(WSFrameEncoder.encodeFrame(frame))
+    }
+
+    func readFrame() async throws -> WSFrame {
+        try await WSFrameEncoder.decodeFrame(from: bytes)
+    }
+}

--- a/FlyingFox/Sources/HTTPClient.swift
+++ b/FlyingFox/Sources/HTTPClient.swift
@@ -38,6 +38,8 @@ public struct _HTTPClient {
         let socket = try await AsyncSocket.connected(to: address)
         try await socket.writeRequest(request)
         let response = try await socket.readResponse()
+        // if streaming very large responses then you shouldn't close here
+        // maybe better to close in deinit instead
         try? socket.close()
         return response
     }

--- a/FlyingFox/Sources/HTTPConnection.swift
+++ b/FlyingFox/Sources/HTTPConnection.swift
@@ -92,7 +92,7 @@ extension HTTPConnection: Hashable {
     }
 }
 
-actor HTTPRequestSequence<S: AsyncChunkedSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable where S.Element == UInt8 {
+actor HTTPRequestSequence<S: AsyncBufferedSequence & Sendable>: AsyncSequence, AsyncIteratorProtocol, @unchecked Sendable where S.Element == UInt8 {
     typealias Element = HTTPRequest
     private let bytes: S
 

--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -34,7 +34,7 @@ import Foundation
 
 struct HTTPDecoder {
 
-    static func decodeRequest<S>(from bytes: S) async throws -> HTTPRequest where S: AsyncChunkedSequence, S.Element == UInt8 {
+    static func decodeRequest(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> HTTPRequest {
         let status = try await bytes.lines.takeNext()
         let comps = status
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -60,7 +60,7 @@ struct HTTPDecoder {
         )
     }
 
-    static func decodeResponse<S>(from bytes: S) async throws -> HTTPResponse where S: AsyncChunkedSequence, S.Element == UInt8 {
+    static func decodeResponse(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> HTTPResponse {
         let comps = try await bytes.lines.takeNext()
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)

--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -34,7 +34,7 @@ import Foundation
 
 struct HTTPDecoder {
 
-    static func decodeRequest(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> HTTPRequest {
+    static func decodeRequest(from bytes: some AsyncBufferedSequence<UInt8>) async throws -> HTTPRequest {
         let status = try await bytes.lines.takeNext()
         let comps = status
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -60,7 +60,7 @@ struct HTTPDecoder {
         )
     }
 
-    static func decodeResponse(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> HTTPResponse {
+    static func decodeResponse(from bytes: some AsyncBufferedSequence<UInt8>) async throws -> HTTPResponse {
         let comps = try await bytes.lines.takeNext()
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .split(separator: " ", maxSplits: 2, omittingEmptySubsequences: true)
@@ -104,7 +104,7 @@ struct HTTPDecoder {
         return (HTTPHeader(name), value)
     }
 
-    static func readHeaders(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> [HTTPHeader : String] {
+    static func readHeaders(from bytes: some AsyncBufferedSequence<UInt8>) async throws -> [HTTPHeader : String] {
         try await bytes
             .lines
             .prefix { $0 != "\r" && $0 != "" }
@@ -112,7 +112,7 @@ struct HTTPDecoder {
             .reduce(into: [HTTPHeader: String]()) { $0[$1.header] = $1.value }
     }
 
-    static func readBody(from bytes: some AsyncChunkedSequence<UInt8>, length: String?, maxSizeForComplete: Int = 10_485_760) async throws -> HTTPBodySequence {
+    static func readBody(from bytes: some AsyncBufferedSequence<UInt8>, length: String?, maxSizeForComplete: Int = 10_485_760) async throws -> HTTPBodySequence {
         guard let length = length.flatMap(Int.init) else {
             return HTTPBodySequence(data: Data())
         }
@@ -124,12 +124,11 @@ struct HTTPDecoder {
         }
     }
 
-    static func makeBodyData(from bytes: some AsyncChunkedSequence<UInt8>, length: Int) async throws -> Data {
+    static func makeBodyData(from bytes: some AsyncBufferedSequence<UInt8>, length: Int) async throws -> Data {
         var iterator = bytes.makeAsyncIterator()
-        guard let buffer = try await iterator.nextChunk(count: length) else {
-            throw Error("AsyncChunkedSequence prematurely ended")
+        guard let buffer = try await iterator.nextBuffer(count: length) else {
+            throw Error("AsyncBufferedSequence prematurely ended")
         }
-
         return Data(buffer)
     }
 }

--- a/FlyingFox/Sources/HTTPDecoder.swift
+++ b/FlyingFox/Sources/HTTPDecoder.swift
@@ -118,7 +118,8 @@ struct HTTPDecoder {
         }
 
         if length <= maxSizeForComplete {
-            return try await HTTPBodySequence(data: makeBodyData(from: bytes, length: length))
+            let data = try await makeBodyData(from: bytes, length: length)
+            return HTTPBodySequence(data: data, bufferSize: 4096)
         } else {
             return HTTPBodySequence(from: bytes, count: length, chunkSize: 4096)
         }

--- a/FlyingFox/Sources/HTTPEncoder.swift
+++ b/FlyingFox/Sources/HTTPEncoder.swift
@@ -42,7 +42,7 @@ struct HTTPEncoder {
         if let contentLength = makeContentLength(from: response.payload) {
             httpHeaders[.contentLength] = String(contentLength)
         } else if let encoding = makeTransferEncoding(from: response.payload) {
-            httpHeaders[.transferEncoding] = encoding
+            httpHeaders.addValue(encoding, for: .transferEncoding)
         }
 
         let headers = httpHeaders.map { "\($0.key.rawValue): \($0.value)" }

--- a/FlyingFox/Sources/HTTPHeader.swift
+++ b/FlyingFox/Sources/HTTPHeader.swift
@@ -63,3 +63,21 @@ public extension HTTPHeader {
     static let transferEncoding = HTTPHeader("Transfer-Encoding")
     static let upgrade          = HTTPHeader("Upgrade")
 }
+
+public extension [HTTPHeader: String] {
+
+    func values(for header: HTTPHeader) -> [String] {
+        let value = self[header] ?? ""
+        return value
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { String($0.trimmingCharacters(in: .whitespaces)) }
+    }
+
+    mutating func setValues(_ values: [String], for header: HTTPHeader) {
+        self[header] = values.joined(separator: ", ")
+    }
+
+    mutating func addValue(_ value: String, for header: HTTPHeader) {
+        setValues(values(for: header) + [value], for: header)
+    }
+}

--- a/FlyingFox/Sources/HTTPHeader.swift
+++ b/FlyingFox/Sources/HTTPHeader.swift
@@ -60,5 +60,6 @@ public extension HTTPHeader {
     static let webSocketAccept  = HTTPHeader("Sec-WebSocket-Accept")
     static let webSocketKey     = HTTPHeader("Sec-WebSocket-Key")
     static let webSocketVersion = HTTPHeader("Sec-WebSocket-Version")
+    static let transferEncoding = HTTPHeader("Transfer-Encoding")
     static let upgrade          = HTTPHeader("Upgrade")
 }

--- a/FlyingFox/Sources/HTTPMethod.swift
+++ b/FlyingFox/Sources/HTTPMethod.swift
@@ -68,7 +68,7 @@ public extension HTTPMethod {
         .TRACE
     ]
 
-    internal static let allMethods = Set(HTTPMethod.sortedMethods)
+    static let allMethods = Set(HTTPMethod.sortedMethods)
 
     static let GET     = HTTPMethod("GET")
     static let POST    = HTTPMethod("POST")
@@ -79,4 +79,17 @@ public extension HTTPMethod {
     static let OPTIONS = HTTPMethod("OPTIONS")
     static let CONNECT = HTTPMethod("CONNECT")
     static let TRACE   = HTTPMethod("TRACE")
+}
+
+public extension Set<HTTPMethod> {
+
+    /// Comma delimited string of methods, sorted to ensure default methods appear first.
+    var stringValue: String {
+        var sortedMethods = HTTPMethod
+            .sortedMethods
+            .filter { contains($0) }
+
+        sortedMethods.append(contentsOf: self.filter { !HTTPMethod.allMethods.contains($0) })
+        return sortedMethods.map(\.rawValue).joined(separator: ",")
+    }
 }

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -90,4 +90,20 @@ extension HTTPRequest {
     var shouldKeepAlive: Bool {
         headers[.connection]?.caseInsensitiveCompare("keep-alive") == .orderedSame
     }
+
+    func pathParameter(for identifier: String) -> String? {
+        let components = path
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map { String($0) }
+
+        guard
+            components.isEmpty == false,
+            let parameterIndex = Self.matchedRoute?.pathParameters[identifier],
+            components.count < parameterIndex
+        else {
+            return nil
+        }
+
+        return components[parameterIndex]
+    }
 }

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -91,7 +91,7 @@ extension HTTPRequest {
         headers[.connection]?.caseInsensitiveCompare("keep-alive") == .orderedSame
     }
 
-    func pathParameter(for identifier: String) -> String? {
+    public func pathParameter(for identifier: String) -> String? {
         let components = path
             .split(separator: "/", omittingEmptySubsequences: true)
             .map { String($0) }

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -84,23 +84,6 @@ public struct HTTPRequest: Sendable {
     }
 }
 
-@available(*, unavailable, message: "HTTPRequest will soon remove conformance to Equatable")
-extension HTTPRequest: Equatable {
-
-    public static func == (lhs: HTTPRequest, rhs: HTTPRequest) -> Bool {
-        guard case .complete(let lhsBody) = lhs.bodySequence.storage,
-              case .complete(let rhsBody) = rhs.bodySequence.storage else {
-            return false
-        }
-        return lhs.method == rhs.method &&
-               lhs.version == rhs.version &&
-               lhs.path == rhs.path &&
-               lhs.query == rhs.query &&
-               lhs.headers == rhs.headers &&
-               lhsBody == rhsBody
-    }
-}
-
 extension HTTPRequest {
     var shouldKeepAlive: Bool {
         headers[.connection]?.caseInsensitiveCompare("keep-alive") == .orderedSame

--- a/FlyingFox/Sources/HTTPRequest.swift
+++ b/FlyingFox/Sources/HTTPRequest.swift
@@ -39,6 +39,8 @@ public struct HTTPRequest: Sendable {
     public var headers: [HTTPHeader: String]
     public var bodySequence: HTTPBodySequence
 
+    @TaskLocal static var matchedRoute: HTTPRoute?
+
     public var bodyData: Data {
         get async throws {
             try await bodySequence.get()

--- a/FlyingFox/Sources/HTTPResponse.swift
+++ b/FlyingFox/Sources/HTTPResponse.swift
@@ -60,17 +60,7 @@ public struct HTTPResponse: Sendable {
 
     @available(*, unavailable, renamed: "bodyData")
     public var body: Data? {
-        switch payload {
-        case .httpBody(let body):
-            switch body.storage {
-            case .complete(let data):
-                return data
-            case .sequence:
-                return nil
-            }
-        case .webSocket:
-            return nil
-        }
+        fatalError("use bodyData")
     }
 
     public init(version: HTTPVersion = .http11,

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -220,7 +220,7 @@ public extension HTTPRoute {
         switch request.storage {
         case .complete(let data):
             return body.evaluate(data)
-        case .sequence:
+        case .dataSequence:
             // HTTPBodyPattern cannot be applied when the body is not completely loaded (large requests)
             return false
         }

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -172,6 +172,10 @@ public extension HTTPRoute.Component {
         guard let node = node else { return false }
         return component.patternMatch(to: node)
     }
+
+    static func ~= (component: HTTPRoute.Component, nodes: [String]) -> Bool {
+        nodes.contains { component.patternMatch(to: $0) }
+    }
 }
 
 public extension HTTPRoute {
@@ -218,7 +222,7 @@ public extension HTTPRoute {
 
     private func patternMatch(headers request: [HTTPHeader: String]) -> Bool {
         return headers.allSatisfy { header, value in
-            value ~= request[header]
+            value ~= request.values(for: header)
         }
     }
 

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -144,8 +144,16 @@ public struct HTTPRoute: Sendable {
     }
 
     @available(*, deprecated, renamed: "methods", message: "Use ``methods`` instead")
-    public var method: String {
-        fatalError("Use ``methods`` instead.")
+    public var method: Component {
+        if methods == HTTPMethod.allMethods {
+            return .wildcard
+        } else {
+            let firstMethod = HTTPMethod.sortedMethods
+                .filter { methods.contains($0) }
+                .first!
+                .rawValue
+            return .caseInsensitive(firstMethod)
+        }
     }
 }
 

--- a/FlyingFox/Sources/HTTPRoute.swift
+++ b/FlyingFox/Sources/HTTPRoute.swift
@@ -200,7 +200,7 @@ public extension HTTPRoute {
         }
     }
 
-    private func pathComponent(for index: Int) -> Component? {
+    func pathComponent(for index: Int) -> Component? {
         if path.indices.contains(index) {
             return path[index]
         } else if path.last == .wildcard {

--- a/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
+++ b/FlyingFox/Sources/Handlers/RoutedHTTPHandler.swift
@@ -60,7 +60,9 @@ public struct RoutedHTTPHandler: HTTPHandler, Sendable {
         for entry in handlers  {
             do {
                 if await entry.route ~= request {
-                    return try await entry.handler.handleRequest(request)
+                    return try await HTTPRequest.$matchedRoute.withValue(entry.route) {
+                        return try await entry.handler.handleRequest(request)
+                    }
                 }
             } catch is HTTPUnhandledError {
                 continue

--- a/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
+++ b/FlyingFox/Sources/WebSocket/AsyncStream+WSFrame.swift
@@ -33,7 +33,7 @@ import FlyingSocks
 
 extension AsyncThrowingStream<WSFrame, any Error> {
 
-    static func decodingFrames(from bytes: some AsyncChunkedSequence<UInt8>) -> Self {
+    static func decodingFrames(from bytes: some AsyncBufferedSequence<UInt8>) -> Self {
         AsyncThrowingStream<WSFrame, any Error> {
             do {
                 return try await WSFrameEncoder.decodeFrame(from: bytes)

--- a/FlyingFox/Sources/WebSocket/WSFrameEncoder.swift
+++ b/FlyingFox/Sources/WebSocket/WSFrameEncoder.swift
@@ -117,7 +117,7 @@ struct WSFrameEncoder {
         }
     }
 
-    static func decodePayload<S>(from bytes: S, length: Int, mask: WSFrame.Mask?) async throws -> Data where S: AsyncChunkedSequence, S.Element == UInt8 {
+    static func decodePayload(from bytes: some AsyncChunkedSequence<UInt8>, length: Int, mask: WSFrame.Mask?) async throws -> Data {
         var iterator = bytes.makeAsyncIterator()
         guard var payload = try await iterator.nextChunk(count: length) else {
             throw SocketError.disconnected
@@ -130,7 +130,7 @@ struct WSFrameEncoder {
         return Data(payload)
     }
 
-    static func decodeLengthMask<S>(from bytes: S) async throws -> (length: Int, mask: WSFrame.Mask?) where S: AsyncChunkedSequence, S.Element == UInt8 {
+    static func decodeLengthMask(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> (length: Int, mask: WSFrame.Mask?) {
         let byte0 = try await bytes.take()
         let hasMask = byte0 & 0b10000000 == 0b10000000
         let length0 = byte0 & 0b01111111
@@ -158,7 +158,7 @@ struct WSFrameEncoder {
         }
     }
 
-    static func decodeMask<S>(from bytes: S) async throws -> WSFrame.Mask where S: AsyncChunkedSequence, S.Element == UInt8 {
+    static func decodeMask(from bytes: some AsyncChunkedSequence<UInt8>) async throws -> WSFrame.Mask {
         try await WSFrame.Mask(m1: bytes.take(),
                                m2: bytes.take(),
                                m3: bytes.take(),

--- a/FlyingFox/Tests/AsyncSocketTests.swift
+++ b/FlyingFox/Tests/AsyncSocketTests.swift
@@ -63,22 +63,6 @@ extension AsyncSocket {
         try await write(string.data(using: .utf8)!)
     }
 
-    func writeRequest(_ request: HTTPRequest) async throws {
-        try await write(HTTPEncoder.encodeRequest(request))
-    }
-
-    func writeFrame(_ frame: WSFrame) async throws {
-        try await write(WSFrameEncoder.encodeFrame(frame))
-    }
-
-    func readResponse() async throws -> HTTPResponse {
-        try await HTTPDecoder.decodeResponse(from: bytes)
-    }
-
-    func readFrame() async throws -> WSFrame {
-        try await WSFrameEncoder.decodeFrame(from: bytes)
-    }
-
     func readString(length: Int) async throws -> String {
         let bytes = try await read(bytes: length)
         guard let string = String(data: Data(bytes), encoding: .utf8) else {

--- a/FlyingFox/Tests/ConsumingAsyncSequence.swift
+++ b/FlyingFox/Tests/ConsumingAsyncSequence.swift
@@ -31,7 +31,7 @@
 
 import FlyingSocks
 
-final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
 
     private var iterator: AnySequence<Element>.Iterator
     private(set) var index: Int = 0
@@ -46,7 +46,7 @@ final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedI
         iterator.next()
     }
 
-    func nextChunk(count: Int) async throws -> [Element]? {
+    func nextBuffer(atMost count: Int) async throws -> [Element]? {
         var buffer = [Element]()
         while buffer.count < count,
               let element = iterator.next() {

--- a/FlyingFox/Tests/HTTPBodySequenceTests.swift
+++ b/FlyingFox/Tests/HTTPBodySequenceTests.swift
@@ -252,7 +252,7 @@ private extension HTTPBodySequence {
     var isComplete: Bool {
         switch storage {
         case .complete: return true
-        case .sequence: return false
+        case .dataSequence: return false
         }
     }
 }

--- a/FlyingFox/Tests/HTTPClientTests.swift
+++ b/FlyingFox/Tests/HTTPClientTests.swift
@@ -1,0 +1,57 @@
+//
+//  HTTPClientTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 8/06/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@_spi(Private) import struct FlyingFox._HTTPClient
+@testable import FlyingFox
+@testable import FlyingSocks
+import XCTest
+import Foundation
+
+final class HTTPClientTests: XCTestCase {
+
+#if canImport(Darwin)
+    func testClient() async throws {
+        // given
+        let server = HTTPServer(address: .loopback(port: 0))
+        let task = Task { try await server.start() }
+        defer { task.cancel() }
+        let client = _HTTPClient()
+
+        // when
+        let port = try await server.waitForListeningPort()
+        let response = try await client.sendHTTPRequest(HTTPRequest.make(), to: .loopback(port: port))
+
+        // then
+        XCTAssertEqual(response.statusCode, .notFound)
+    }
+#endif
+
+}

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -191,8 +191,8 @@ final class HTTPDecoderTests: XCTestCase {
 
     func testBody_ThrowsError_WhenSequenceEnds() async throws {
         await AsyncAssertThrowsError(
-            _ = try await HTTPDecoder.readBody(from: EmptyChunkedSequence(), length: "100"),
-            of: HTTPDecoder.Error.self
+            _ = try await HTTPDecoder.readBody(from: EmptyBufferedSequence(), length: "100"),
+            of: SocketError.self
         )
     }
 
@@ -315,16 +315,16 @@ private extension HTTPDecoder {
     }
 }
 
-private struct EmptyChunkedSequence: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+private struct EmptyBufferedSequence: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
     mutating func next() async throws -> UInt8? {
         return nil
     }
 
-    mutating func nextChunk(count: Int) async throws -> [Element]? {
+    func nextBuffer(atMost count: Int) async throws -> [Element]? {
         return nil
     }
 
-    func makeAsyncIterator() -> EmptyChunkedSequence {
+    func makeAsyncIterator() -> EmptyBufferedSequence {
         self
     }
 

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -196,16 +196,16 @@ final class HTTPDecoderTests: XCTestCase {
         )
     }
 
-    func testBodySequence_IsComplete_WhenSizeIsLessThanMax() async throws {
+    func testBodySequence_CanReplay_WhenSizeIsLessThanMax() async throws {
         let sequence = try await HTTPDecoder.readBodyFromString("Fish & Chips", maxSizeForComplete: 100)
         XCTAssertEqual(sequence.count, 12)
-        XCTAssertTrue(sequence.storage.isComplete)
+        XCTAssertTrue(sequence.canReplay)
     }
 
-    func testBodySequence_IsNotComplete_WhenSizeIsGreaterThanMax() async throws {
+    func testBodySequence_CanNotReplay_WhenSizeIsGreaterThanMax() async throws {
         let sequence = try await HTTPDecoder.readBodyFromString("Fish & Chips", maxSizeForComplete: 2)
         XCTAssertEqual(sequence.count, 12)
-        XCTAssertFalse(sequence.storage.isComplete)
+        XCTAssertFalse(sequence.canReplay)
     }
 
     func testInvalidPathDecodes() {
@@ -329,13 +329,4 @@ private struct EmptyBufferedSequence: AsyncBufferedSequence, AsyncBufferedIterat
     }
 
     typealias Element = UInt8
-}
-
-extension HTTPBodySequence.Storage {
-    var isComplete: Bool {
-        switch self {
-        case .complete: return true
-        case .dataSequence: return false
-        }
-    }
 }

--- a/FlyingFox/Tests/HTTPDecoderTests.swift
+++ b/FlyingFox/Tests/HTTPDecoderTests.swift
@@ -335,7 +335,7 @@ extension HTTPBodySequence.Storage {
     var isComplete: Bool {
         switch self {
         case .complete: return true
-        case .sequence: return false
+        case .dataSequence: return false
         }
     }
 }

--- a/FlyingFox/Tests/HTTPEncoderTests.swift
+++ b/FlyingFox/Tests/HTTPEncoderTests.swift
@@ -128,7 +128,7 @@ final class HTTPEncoderTests: XCTestCase {
             .makeChunked(
                 version: .http11,
                 statusCode: .ok,
-                headers: [:],
+                headers: [.transferEncoding: "Fish"],
                 body: "Hello World!".data(using: .utf8)!,
                 chunkSize: 10
             )
@@ -138,7 +138,7 @@ final class HTTPEncoderTests: XCTestCase {
             data,
             """
             HTTP/1.1 200 OK\r
-            Transfer-Encoding: chunked\r
+            Transfer-Encoding: Fish, chunked\r
             \r
             0A\r
             Hello Worl\r

--- a/FlyingFox/Tests/HTTPHeaderTests.swift
+++ b/FlyingFox/Tests/HTTPHeaderTests.swift
@@ -1,0 +1,70 @@
+//
+//  HTTPHeaderTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 11/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingFox
+import Foundation
+import XCTest
+
+final class HTTPHeaderTests: XCTestCase {
+
+    func testStringValue() {
+        // given
+        var headers = [HTTPHeader: String]()
+        headers[.transferEncoding] = "Identity"
+
+        XCTAssertEqual(
+            headers[.transferEncoding],
+            "Identity"
+        )
+
+        XCTAssertEqual(
+            headers.values(for: .transferEncoding),
+            ["Identity"]
+        )
+
+        XCTAssertEqual(
+            headers.values(for: .contentType),
+            []
+        )
+    
+        headers.addValue("chunked", for: .transferEncoding)
+
+        XCTAssertEqual(
+            headers[.transferEncoding],
+            "Identity, chunked"
+        )
+
+        XCTAssertEqual(
+            headers.values(for: .transferEncoding),
+            ["Identity", "chunked"]
+        )
+    }
+}

--- a/FlyingFox/Tests/HTTPMethodTests.swift
+++ b/FlyingFox/Tests/HTTPMethodTests.swift
@@ -1,0 +1,44 @@
+//
+//  HTTPMethodTests.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 11/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+@testable import FlyingFox
+import Foundation
+import XCTest
+
+final class HTTPMethodTests: XCTestCase {
+
+    func testStringValue() {
+        XCTAssertEqual(
+            Set([HTTPMethod("fish"), .DELETE, .POST]).stringValue,
+            "POST,DELETE,FISH"
+        )
+    }
+}

--- a/FlyingFox/Tests/HTTPResponse+Mock.swift
+++ b/FlyingFox/Tests/HTTPResponse+Mock.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-import FlyingFox
+@testable import FlyingFox
 import Foundation
 
 extension HTTPResponse {
@@ -43,6 +43,22 @@ extension HTTPResponse {
                      headers: headers,
                      body: body)
     }
+
+#if compiler(>=5.9)
+    static func makeChunked(version: HTTPVersion = .http11,
+                            statusCode: HTTPStatusCode  = .ok,
+                            headers: [HTTPHeader: String] = [:],
+                            body: Data = Data(),
+                            chunkSize: Int = 5) -> Self {
+        let consuming = ConsumingAsyncSequence(body)
+        return HTTPResponse(
+            version: version,
+            statusCode: statusCode,
+            headers: headers,
+            body: HTTPBodySequence(from: consuming, bufferSize: chunkSize)
+        )
+    }
+#endif
 
     static func make(version: HTTPVersion = .http11,
                      statusCode: HTTPStatusCode  = .ok,

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -430,4 +430,11 @@ final class HTTPRouteTests: XCTestCase {
         )
     }
 #endif
+
+    func testDeprecated_Method() {
+        XCTAssertEqual(HTTPRoute("/fish/*").method, .wildcard)
+        XCTAssertEqual(HTTPRoute("GET /fish/*").method, .caseInsensitive("GET"))
+        XCTAssertEqual(HTTPRoute("PUT /fish/*").method, .caseInsensitive("PUT"))
+        XCTAssertEqual(HTTPRoute("GET,PUT /fish/*").method, .caseInsensitive("GET"))
+    }
 }

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -339,6 +339,12 @@ final class HTTPRouteTests: XCTestCase {
         await AsyncAssertTrue(
             await route ~= HTTPRequest.make(method: .GET,
                                       path: "/mock",
+                                      headers: [.contentType: "xml, json"])
+        )
+
+        await AsyncAssertTrue(
+            await route ~= HTTPRequest.make(method: .GET,
+                                      path: "/mock",
                                       headers: [.contentEncoding: "xml",
                                                 .contentType: "json"])
         )

--- a/FlyingFox/Tests/HTTPRouteTests.swift
+++ b/FlyingFox/Tests/HTTPRouteTests.swift
@@ -443,4 +443,25 @@ final class HTTPRouteTests: XCTestCase {
         XCTAssertEqual(HTTPRoute("PUT /fish/*").method, .caseInsensitive("PUT"))
         XCTAssertEqual(HTTPRoute("GET,PUT /fish/*").method, .caseInsensitive("GET"))
     }
+
+    func testPathParameters() async {
+        let route = HTTPRoute("GET /mock/:id")
+        let parameters = route.pathParameters
+        XCTAssertEqual(parameters.count, 1)
+        XCTAssertEqual(parameters["id"], 1) // Position 1 in the components array
+
+        let route2 = HTTPRoute("GET /mock/:id/:bloop/hello/guys/:zonk")
+        let parameters2 = route2.pathParameters
+        XCTAssertEqual(parameters2.count, 3)
+        XCTAssertEqual(parameters2["id"], 1)
+        XCTAssertEqual(parameters2["bloop"], 2)
+        XCTAssertEqual(parameters2["zonk"], 5)
+
+        let route3 = HTTPRoute("GET /mock/:id/not:bloop/hello/guys/:zonk")
+        let parameters3 = route3.pathParameters
+        XCTAssertEqual(parameters3.count, 2)
+        XCTAssertEqual(parameters3["id"], 1)
+        XCTAssertNil(parameters3["bloop"])
+        XCTAssertEqual(parameters2["zonk"], 5)
+    }
 }

--- a/FlyingFox/Tests/HTTPServerTests.swift
+++ b/FlyingFox/Tests/HTTPServerTests.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-@testable import FlyingFox
+@_spi(Private) @testable import FlyingFox
 @testable import FlyingSocks
 import XCTest
 import Foundation

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -93,7 +93,7 @@ private extension HTTPRoute {
 
 private extension HTTPRoute.Component {
 
-    var stringValue: String? {
+    var stringValue: String {
         switch self {
         case .wildcard:
             return "*"

--- a/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
+++ b/FlyingFox/Tests/Handlers/RoutedHTTPHandlerTests.swift
@@ -93,12 +93,14 @@ private extension HTTPRoute {
 
 private extension HTTPRoute.Component {
 
-    var stringValue: String {
+    var stringValue: String? {
         switch self {
         case .wildcard:
             return "*"
         case let .caseInsensitive(pattern):
             return pattern
+        case let .parameter(name):
+            return ":" + name
         }
     }
 }

--- a/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
+++ b/FlyingFox/Tests/WebSocket/WSFrameEncoderTests.swift
@@ -29,7 +29,7 @@
 //  SOFTWARE.
 //
 
-@testable import FlyingFox
+@_spi(Private) @testable import FlyingFox
 @testable import FlyingSocks
 import Foundation
 import XCTest

--- a/FlyingSocks.podspec.json
+++ b/FlyingSocks.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "FlyingSocks",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "summary": "Lightweight, async sockets written in Swift using async/await",
   "homepage": "https://github.com/swhitty/FlyingFox",
   "authors": "Simon Whitty",
@@ -10,7 +10,7 @@
   },
   "source": {
     "git": "https://github.com/swhitty/FlyingFox.git",
-    "tag": "0.14.0"
+    "tag": "0.15.0"
   },
   "platforms": {
     "ios": "13.0",

--- a/FlyingSocks/Sources/AsyncBufferedCollection.swift
+++ b/FlyingSocks/Sources/AsyncBufferedCollection.swift
@@ -81,15 +81,3 @@ public extension AsyncBufferedCollection<Data> {
     }
 }
 
-public extension AsyncBufferedCollection {
-
-    func collectChunks(ofLength count: Int) async -> [C.SubSequence] {
-        var collected = [C.SubSequence]()
-        var iterator = makeAsyncIterator()
-
-        while let buffer = await iterator.nextBuffer(atMost: count) {
-            collected.append(buffer)
-        }
-        return collected
-    }
-}

--- a/FlyingSocks/Sources/AsyncBufferedDataSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedDataSequence.swift
@@ -1,0 +1,95 @@
+//
+//  AsyncBufferedDataSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 10/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+@_spi(Private)
+public struct AsyncBufferedCollection<C: Collection>: AsyncBufferedSequence {
+    public typealias Element = C.Element
+
+    private let collection: C
+
+    public init(_ collection: C) {
+        self.collection = collection
+    }
+
+    public func makeAsyncIterator() -> Iterator {
+        Iterator(collection: collection)
+    }
+
+    public struct Iterator: AsyncBufferedIteratorProtocol {
+
+        private let collection: C
+        private var index: C.Index
+
+        init(collection: C) {
+            self.collection = collection
+            self.index = collection.startIndex
+        }
+
+        public mutating func next() async throws -> C.Element? {
+            guard index < collection.endIndex else { return nil }
+            let element = collection[index]
+            index = collection.index(after: index)
+            return element
+        }
+
+        public mutating func nextBuffer(atMost count: Int) async -> C.SubSequence? {
+            guard index < collection.endIndex else { return nil }
+            let endIndex = collection.index(index, offsetBy: count, limitedBy: collection.endIndex) ?? collection.endIndex
+            let buffer = collection[index..<endIndex]
+            index = endIndex
+            return buffer
+        }
+    }
+}
+
+extension AsyncBufferedCollection: Sendable where C: Sendable { }
+
+
+public extension AsyncBufferedCollection<Data> {
+    init(bytes: some Sequence<UInt8>) {
+        self.init(Data(bytes))
+    }
+}
+
+public extension AsyncBufferedCollection {
+
+    func collectChunks(ofLength count: Int) async -> [C.SubSequence] {
+        var collected = [C.SubSequence]()
+        var iterator = makeAsyncIterator()
+
+        while let buffer = await iterator.nextBuffer(atMost: count) {
+            collected.append(buffer)
+        }
+        return collected
+    }
+}

--- a/FlyingSocks/Sources/AsyncBufferedSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence.swift
@@ -40,7 +40,7 @@ public protocol AsyncBufferedIteratorProtocol<Element>: AsyncIteratorProtocol {
 
     /// Retrieves available elements from the buffer. Suspends if 0 elements are available.
     /// - Parameter count: The maximum number of elements to return
-    /// - Returns: Array with between 1 and the number elements that was requested. Nil is returned if the sequence has ended.
+    /// - Returns: Collection with between 1 and the number elements that was requested. Nil is returned if the sequence has ended.
     mutating func nextBuffer(atMost count: Int) async throws -> Buffer?
 }
 

--- a/FlyingSocks/Sources/AsyncBufferedSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence.swift
@@ -1,0 +1,67 @@
+//
+//  AsyncBufferedSequence.swift
+//  FlyingFox
+//
+//  Created by Simon Whitty on 06/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
+//
+//  Distributed under the permissive MIT license
+//  Get the latest version from here:
+//
+//  https://github.com/swhitty/FlyingFox
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+/// AsyncSequence that is buffered and can optionally receive contiguous elements in chunks, instead of just one-at-a-time.
+public protocol AsyncBufferedSequence<Element>: AsyncSequence where AsyncIterator: AsyncBufferedIteratorProtocol {
+
+}
+
+public protocol AsyncBufferedIteratorProtocol: AsyncIteratorProtocol {
+    // Buffered elements are returned in this collection type
+    associatedtype Buffer: Collection where Buffer.Element == Element
+
+    /// Retrieves available elements from the buffer. Suspends if 0 elements are available.
+    /// - Parameter count: The maximum number of elements to return
+    /// - Returns: Array with between 1 and the number elements that was requested. Nil is returned if the sequence has ended.
+    mutating func nextBuffer(atMost count: Int) async throws -> Buffer?
+}
+
+public extension AsyncBufferedIteratorProtocol {
+
+    /// Retrieves n elements from sequence in a single array.
+    /// - Parameter count: The maximum number of elements to return
+    /// - Returns: Array with the number of elements that was requested. Nil is returned if the sequence has ended.
+    mutating func nextBuffer(count: Int) async throws -> [Element]? {
+        guard count > 0 else { return [] }
+
+        var buffer = [Element]()
+        while buffer.count < count {
+            try Task.checkCancellation()
+            let remaining = count - buffer.count
+            if let chunk = try await nextBuffer(atMost: remaining) {
+                buffer.append(contentsOf: chunk)
+            } else {
+                throw SocketError.disconnected
+            }
+        }
+        return buffer.isEmpty ? nil : buffer
+    }
+}

--- a/FlyingSocks/Sources/AsyncBufferedSequence.swift
+++ b/FlyingSocks/Sources/AsyncBufferedSequence.swift
@@ -34,7 +34,7 @@ public protocol AsyncBufferedSequence<Element>: AsyncSequence where AsyncIterato
 
 }
 
-public protocol AsyncBufferedIteratorProtocol: AsyncIteratorProtocol {
+public protocol AsyncBufferedIteratorProtocol<Element>: AsyncIteratorProtocol {
     // Buffered elements are returned in this collection type
     associatedtype Buffer: Collection where Buffer.Element == Element
 

--- a/FlyingSocks/Sources/AsyncChunkedSequence.swift
+++ b/FlyingSocks/Sources/AsyncChunkedSequence.swift
@@ -30,10 +30,12 @@
 //
 
 /// AsyncSequence that is able to also receive elements in chunks, instead of just one-at-a-time.
+@available(*, deprecated, renamed: "AsyncBufferedSequence")
 public protocol AsyncChunkedSequence<Element>: AsyncSequence where AsyncIterator: AsyncChunkedIteratorProtocol {
 
 }
 
+@available(*, deprecated, renamed: "AsyncBufferedIteratorProtocol")
 public protocol AsyncChunkedIteratorProtocol: AsyncIteratorProtocol {
 
     /// Retrieves n elements from sequence in a single array.
@@ -41,12 +43,12 @@ public protocol AsyncChunkedIteratorProtocol: AsyncIteratorProtocol {
     mutating func nextChunk(count: Int) async throws -> [Element]?
 }
 
-@available(*, unavailable, renamed: "AsyncChunkedSequence")
+@available(*, unavailable, renamed: "AsyncBufferedSequence")
 public protocol ChunkedAsyncSequence: AsyncSequence where AsyncIterator: ChunkedAsyncIteratorProtocol {
 
 }
 
-@available(*, unavailable, renamed: "AsyncChunkedIteratorProtocol")
+@available(*, unavailable, renamed: "AsyncBufferedIteratorProtocol")
 public protocol ChunkedAsyncIteratorProtocol: AsyncIteratorProtocol {
     mutating func nextChunk(count: Int) async throws -> [Element]?
 }

--- a/FlyingSocks/Sources/AsyncDataSequence.swift
+++ b/FlyingSocks/Sources/AsyncDataSequence.swift
@@ -38,11 +38,11 @@ public struct AsyncDataSequence: AsyncSequence, Sendable {
 
     private let loader: DataLoader
 
-    public init(from bytes: some AsyncChunkedSequence<UInt8>, count: Int, chunkSize: Int) {
+    public init(from bytes: some AsyncBufferedSequence<UInt8>, count: Int, chunkSize: Int) {
         self.loader = DataLoader(
             count: count,
             chunkSize: chunkSize,
-            iterator: AsyncChunkedSequenceIterator(bytes.makeAsyncIterator())
+            iterator: AsyncBufferedSequenceIterator(bytes.makeAsyncIterator())
         )
     }
 
@@ -166,7 +166,7 @@ private extension AsyncDataSequence {
         }
     }
 
-    final class AsyncChunkedSequenceIterator<I: AsyncChunkedIteratorProtocol>: AsyncDataIterator, @unchecked Sendable where I.Element == UInt8 {
+    final class AsyncBufferedSequenceIterator<I: AsyncBufferedIteratorProtocol>: AsyncDataIterator, @unchecked Sendable where I.Element == UInt8 {
         private var iterator: I
 
         init(_ iterator: I) {
@@ -174,8 +174,8 @@ private extension AsyncDataSequence {
         }
 
         func nextChunk(count: Int) async throws -> Data? {
-            guard let chunk = try await iterator.nextChunk(count: count) else { return nil }
-            return Data(chunk)
+            guard let buffer = try await iterator.nextBuffer(count: count) else { return nil }
+            return Data(buffer)
         }
     }
 

--- a/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
@@ -1,9 +1,9 @@
 //
-//  ConsumingAsyncSequence.swift
+//  AsyncBufferedDataSequenceTests.swift
 //  FlyingFox
 //
-//  Created by Simon Whitty on 17/02/2022.
-//  Copyright © 2022 Simon Whitty. All rights reserved.
+//  Created by Simon Whitty on 10/07/2024.
+//  Copyright © 2024 Simon Whitty. All rights reserved.
 //
 //  Distributed under the permissive MIT license
 //  Get the latest version from here:
@@ -29,30 +29,42 @@
 //  SOFTWARE.
 //
 
-import FlyingSocks
+@_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
+import Foundation
+import XCTest
 
-final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
+final class AsyncBufferedDataSequenceTests: XCTestCase {
 
-    private var iterator: AnySequence<Element>.Iterator
-    private(set) var index: Int = 0
+    func testSeqeunce() async {
+        let buffer = AsyncBufferedCollection(bytes: [
+            0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+            0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF
+        ])
 
-    init<T: Sequence>(_ sequence: T) where T.Element == Element {
-        self.iterator = AnySequence(sequence).makeIterator()
+        await AsyncAssertEqual(
+            await buffer.collectChunks(ofLength: 5),
+            [
+                Data([0x0, 0x1, 0x2, 0x3, 0x4]),
+                Data([0x5, 0x6, 0x7, 0x8, 0x9]),
+                Data([0xA, 0xB, 0xC, 0xD, 0xE]),
+                Data([0xF])
+            ]
+        )
     }
 
-    func makeAsyncIterator() -> ConsumingAsyncSequence<Element> { self }
+    func testSequenceCanBeIteratorMultipleTimes() async {
+        let buffer = AsyncBufferedCollection(bytes: [
+            0x0, 0x1, 0x2
+        ])
 
-    func next() async throws -> Element? {
-        iterator.next()
-    }
+        await AsyncAssertEqual(
+            await buffer.collectChunks(ofLength: 5),
+            [Data([0x0, 0x1, 0x2])]
+        )
 
-    func nextBuffer(atMost count: Int) async throws -> [Element]? {
-        var buffer = [Element]()
-        while buffer.count < count,
-              let element = iterator.next() {
-            buffer.append(element)
-        }
-        index += buffer.count
-        return buffer.count > 0 ? buffer : nil
+        await AsyncAssertEqual(
+            await buffer.collectChunks(ofLength: 5),
+            [Data([0x0, 0x1, 0x2])]
+        )
     }
 }

--- a/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncBufferedDataSequenceTests.swift
@@ -30,6 +30,7 @@
 //
 
 @_spi(Private) import struct FlyingSocks.AsyncBufferedCollection
+import FlyingSocks
 import Foundation
 import XCTest
 
@@ -42,7 +43,7 @@ final class AsyncBufferedDataSequenceTests: XCTestCase {
         ])
 
         await AsyncAssertEqual(
-            await buffer.collectChunks(ofLength: 5),
+            await buffer.collectBuffers(ofLength: 5),
             [
                 Data([0x0, 0x1, 0x2, 0x3, 0x4]),
                 Data([0x5, 0x6, 0x7, 0x8, 0x9]),
@@ -58,13 +59,26 @@ final class AsyncBufferedDataSequenceTests: XCTestCase {
         ])
 
         await AsyncAssertEqual(
-            await buffer.collectChunks(ofLength: 5),
+            await buffer.collectBuffers(ofLength: 5),
             [Data([0x0, 0x1, 0x2])]
         )
 
         await AsyncAssertEqual(
-            await buffer.collectChunks(ofLength: 5),
+            await buffer.collectBuffers(ofLength: 5),
             [Data([0x0, 0x1, 0x2])]
         )
+    }
+}
+
+private extension AsyncBufferedSequence {
+
+    func collectBuffers(ofLength count: Int) async -> [AsyncIterator.Buffer] {
+        var collected = [AsyncIterator.Buffer]()
+        var iterator = makeAsyncIterator()
+
+        while let buffer = try? await iterator.nextBuffer(atMost: count) {
+            collected.append(buffer)
+        }
+        return collected
     }
 }

--- a/FlyingSocks/Tests/AsyncDataSequenceTests.swift
+++ b/FlyingSocks/Tests/AsyncDataSequenceTests.swift
@@ -268,7 +268,7 @@ extension AsyncDataSequence {
     }
 }
 
-private final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, AsyncChunkedIteratorProtocol {
+private final class ConsumingAsyncSequence<Element>: AsyncBufferedSequence, AsyncBufferedIteratorProtocol {
 
     private var iterator: AnySequence<Element>.Iterator
     private(set) var index: Int = 0
@@ -283,7 +283,7 @@ private final class ConsumingAsyncSequence<Element>: AsyncChunkedSequence, Async
         iterator.next()
     }
 
-    func nextChunk(count: Int) async throws -> [Element]? {
+    func nextBuffer(atMost count: Int) async throws -> [Element]? {
         var buffer = [Element]()
         while buffer.count < count,
               let element = iterator.next() {

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "FlyingFox",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v8)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ FlyingFox can be installed by using Swift Package Manager.
 To install using Swift Package Manager, add this to the `dependencies:` section in your Package.swift file:
 
 ```swift
-.package(url: "https://github.com/swhitty/FlyingFox.git", .upToNextMajor(from: "0.14.0"))
+.package(url: "https://github.com/swhitty/FlyingFox.git", .upToNextMajor(from: "0.15.0"))
 ```
 
 # Usage


### PR DESCRIPTION
This PR proposes support for parameters in paths, by using the syntax from Vapor and other prior implementations: `/some-url/:parameter1/more-url/:parameter2`